### PR TITLE
A collection of recent changes

### DIFF
--- a/config/fish/config.fish
+++ b/config/fish/config.fish
@@ -6,7 +6,6 @@ set -gx AWS_DEFAULT_PROFILE ReplayProdDev
 set -gx PATH ~/google-cloud-sdk/bin $PATH
 
 set -gx GOPATH $HOME/go
-set -gx GOROOT $HOME/.go
 set -gx PATH $GOPATH/bin $PATH
 
 set -gx EARTHLY_SSH_AUTH_SOCK $SSH_AUTH_SOCK
@@ -41,17 +40,10 @@ if command -v direnv > /dev/null
   eval (direnv hook fish)
 end
 
-if command -v direnv > /dev/null
-  pyenv init - | source
-end
-
-if command -v nvm > /dev/null
-  nvm use 18
-end
+nvm use 18 --silent
 
 # E.g. kill_server 3000 will kill anything listening on 3000 other than firefox
 # or chrome
 function kill_server
   kill -9 (lsof -i tcp:$argv[1] -t -c^Google -c^firefox)
 end
-

--- a/config/kitty/kitty.conf
+++ b/config/kitty/kitty.conf
@@ -4,11 +4,13 @@ include themes/frappe.conf
 
 font_family Cartograph CF
 
-font_size 16.0
+font_size 14.0
 
 # Copy to clipboard using cmd+c
 map super+c copy_to_clipboard
 map super+v paste_from_clipboard
+
+map super+t new_tab_with_cwd
 
 scrollback_lines 10000
 
@@ -16,14 +18,6 @@ enable_audio_bell no
 
 # Don't hide the mouse.
 mouse_hide_wait 0
-
-# https://sw.kovidgoyal.net/kitty/conf/#fonts
- font_features Cartograph CF -liga
- font_features Cartograph CF -liga
- font_features Cartograph CF Italic -liga
- font_features MonoLisa -liga
- font_features MonoLisa -liga
- font_features MonoLisa Italic -liga
 
 map super+0 change_font_size all 0
 map super+equal change_font_size all +2.0
@@ -53,6 +47,6 @@ copy_on_select yes
 
 
 # BEGIN_KITTY_THEME
-# Rosé Pine Moon
+# Rosé Pine
 include current-theme.conf
 # END_KITTY_THEME

--- a/config/nvim/after/plugin/formatter.lua
+++ b/config/nvim/after/plugin/formatter.lua
@@ -17,6 +17,9 @@ formatter.setup({
     rust = {
       require("formatter.filetypes.rust").rustfmt,
     },
+    go = {
+      require("formatter.filetypes.go").gofmt,
+    },
     ["*"] = {
       require("formatter.filetypes.any").remove_trailing_whitespace,
     },

--- a/config/nvim/after/plugin/rose-pine.lua
+++ b/config/nvim/after/plugin/rose-pine.lua
@@ -1,6 +1,5 @@
 require("rose-pine").setup({
-  variant = "moon",
-  dark_variant = "moon",
+  -- dark_variant = "moon",
   bold_vert_split = false,
   dim_nc_background = false,
   disable_background = false,

--- a/config/nvim/lua/jcmorrow/init.lua
+++ b/config/nvim/lua/jcmorrow/init.lua
@@ -1,3 +1,6 @@
 require("jcmorrow.packer")
 require("jcmorrow.set")
 require("jcmorrow.remap")
+vim.cmd [[
+  autocmd BufReadPre * if getfsize(expand("%")) > 10000000 | syntax off | endif
+]]

--- a/config/nvim/lua/jcmorrow/packer.lua
+++ b/config/nvim/lua/jcmorrow/packer.lua
@@ -19,6 +19,7 @@ return require("packer").startup(function(use)
   use({ "mbbill/undotree" })
   use({ "tpope/vim-fugitive" })
   use({ "tpope/vim-rhubarb" })
+  use({ "tpope/vim-commentary" })
   use({ "junegunn/goyo.vim" })
 
   use({ "mhartington/formatter.nvim" })

--- a/config/nvim/lua/jcmorrow/remap.lua
+++ b/config/nvim/lua/jcmorrow/remap.lua
@@ -10,6 +10,7 @@ vim.keymap.set("x", "<leader>p", '"_dP')
 
 vim.keymap.set("n", "<C-k>", "<cmd>cnext<CR>zz")
 vim.keymap.set("n", "<C-j>", "<cmd>cprev<CR>zz")
+vim.keymap.set("n", "<leader><leader>", "<c-^>")
 
 vim.keymap.set(
   "n",

--- a/config/nvim/lua/jcmorrow/set.lua
+++ b/config/nvim/lua/jcmorrow/set.lua
@@ -1,18 +1,24 @@
-vim.opt.guicursor = ""
+vim.g.mapleader = " "
 
-vim.opt.nu = true
+vim.opt.shell = "fish"
+
+vim.opt.termguicolors = true
+
+vim.opt.guicursor = ""
+vim.opt.scrolloff = 8
+
+vim.opt.number = true
 vim.opt.relativenumber = true
 
 vim.opt.tabstop = 2
 vim.opt.softtabstop = 2
 vim.opt.shiftwidth = 2
 vim.opt.expandtab = true
-
 vim.opt.smartindent = true
+vim.opt.wrap = false
+vim.opt.colorcolumn = "80"
 
 vim.cmd("set list listchars=tab:»·,trail:·,nbsp:·")
-
-vim.opt.wrap = false
 
 vim.opt.swapfile = false
 vim.opt.backup = false
@@ -21,12 +27,5 @@ vim.opt.undodir = os.getenv("HOME") .. "/.vim/undodir"
 vim.opt.hlsearch = false
 vim.opt.incsearch = true
 
-vim.opt.termguicolors = true
-
-vim.opt.scrolloff = 8
-
 vim.opt.updatetime = 50
-
-vim.opt.colorcolumn = "80"
-
-vim.g.mapleader = " "
+vim.opt.clipboard = "unnamed"

--- a/gitconfig
+++ b/gitconfig
@@ -77,3 +77,8 @@ defaultRemote=origin
 	ff = only
 [init]
 	defaultBranch = main
+[filter "lfs"]
+	smudge = git-lfs smudge -- %f
+	process = git-lfs filter-process
+	required = true
+	clean = git-lfs clean -- %f


### PR DESCRIPTION
- Add commentary. (https://github.com/tpope/vim-commentary
- Remove GO_ROOT. (https://dave.cheney.net/2013/06/14/you-dont-need-to-set-goroot-really)
- Move nvm initialization out of if statement.
- Remove pyenv config because A. it was misconfigured and B. I don't really write python these days.
- Rose Pine Moon -> Rose Pine
- Allow ligatures again - funny story: this code disabling ligatures at the kitty level no longer works for some reason. As a product of that I've been using ligatures again, and I kind of think they are nice. I also saw someone commenting on HN about how the article which had convinced me to *stop* using ligatures also had a sentence about how if you personally like them it's probably fine to use them, but if you are going to share some code it should probably not have ligatures for clarity purposes, which I agree with.
- Map cmd+t to open a new tab *in the current directory*
- Add gofmt to vim.
- Turn off syntax highlighting in really, really big files. When opening a big log file nvim was using many GB of memory.
- Re-add `<leader><leader>` to "go to last file" for fast switching back and forth.
- Shuffle some vim config lines around.
- Random git lfs config? Not sure how this got here and I don't really care tbh.
